### PR TITLE
`rmp-serde` support & docs for features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 build = "build.rs"
 keywords = ["serialization", "interoperability", "data-consistency", "flexibility", "performance"]
 categories = ["data-structures", "encoding", "rust-patterns"]
+rust-version = "1.73.0"
 
 [workspace]
 members = ["native_model_macro"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,12 @@ native_model_macro = { version = "0.4.11", path = "native_model_macro" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 bincode_1_3 = { package = "bincode", version = "1.3", optional = true }
 bincode_2_rc = { package = "bincode", version = "2.0.0-rc.3", features = ["serde"], optional = true }
+<<<<<<< HEAD
 postcard_1_0 = { package = "postcard", version = "1.0", features = ["alloc"], optional = true }
+=======
+postcard_1_0 = { package = "postcard", version = "1.0.8", features = ["alloc"], optional = true }
+rmp_serde_1_3 = { package = "rmp-serde", version = "1.3", optional = true }
+>>>>>>> 3576bad (Improved codec docs & support for `rmp-serde` `1.3`)
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,7 @@ criterion = { version = "0.5.1" }
 skeptic = "0.13"
 
 [features]
-# default = ["serde", "bincode_1_3"]
-default = ["serde", "bincode_1_3", "bincode_2_rc", "postcard_1_0", "rmp_serde_1_3"]
+default = ["serde", "bincode_1_3"]
 
 [[bench]]
 name = "overhead"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,17 @@ categories = ["data-structures", "encoding", "rust-patterns"]
 members = ["native_model_macro"]
 
 [dependencies]
+<<<<<<< HEAD
 zerocopy = { version = "0.7.32", features = [ "derive"] }
 thiserror = "1.0"
 anyhow = "1.0"
 native_model_macro = { version = "0.4.11", path = "native_model_macro" }
+=======
+zerocopy = { version = "0.7.33", features = ["derive"] }
+thiserror = "1.0.59"
+anyhow = "1.0.82"
+native_model_macro = { version = "0.4.19", path = "native_model_macro" }
+>>>>>>> b6d3bd4 (Removed `#![feature(doc_cfg)]` nightly feature)
 
 serde = { version = "1.0", features = ["derive"], optional = true }
 bincode_1_3 = { package = "bincode", version = "1.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,8 @@ criterion = { version = "0.5.1" }
 skeptic = "0.13"
 
 [features]
-default = ["serde", "bincode_1_3"]
+# default = ["serde", "bincode_1_3"]
+default = ["serde", "bincode_1_3", "bincode_2_rc", "postcard_1_0", "rmp_serde_1_3"]
 
 [[bench]]
 name = "overhead"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,53 @@ struct Cord {
 // Implement the conversion between versions From<DotV2> for DotV3 and From<DotV3> for DotV2.
 ```
 
+## Codecs
+
+`native_model` comes with several optional built-in serializer features available:
+
+- [bincode 1.3](https://crates.io/crates/bincode/1.3.3)
+	- This is the default codec.
+	- **Warning: This codec may not work with all serde-derived types.**
+
+- [bincode 2.0.0-rc.3](https://crates.io/crates/bincode/2.0.0-rc.3)
+	- Enable the `bincode_2_rc` feature and use the `native_model::bincode_2_rc::Bincode` attribute to have `native_db` use this crate for serializing & deserializing.
+	- **Warning: This codec may not work with all serde-derived types.**
+
+- [postcard 1.0](https://crates.io/crates/postcard/1.0.8)
+	- Enable the `postcard_1_0` feature and use the `native_model::postcard_1_0::PostCard` attribute.
+	- **Warning: This codec may not work with all serde-derived types.**
+
+- [rmp-serde 1.3](https://crates.io/crates/rmp-serde/1.3.0)
+	- Enable the `rmp_serde_1_3` feature and use the `native_model::rmp_serde_1_3::RmpSerde` attribute.
+
+###### Codec example:
+
+As example, to use `rmp-serde`:
+
+1. In your project's `Cargo.toml` file, enable the `rmp_serde_1_3` feature for the `native_model` dependency.
+	- Be sure to check `crates.io` for the most recent [`native_model`](https://crates.io/crates/native_model) version number.
+
+```toml
+[dependencies]
+serde = { version = "1.0", features = [ "derive" ] }
+native_model = { version = "0.4", features = [ "rmp_serde_1_3" ] }
+```
+
+2. Assign the `rmp_serde_1_3` codec to your `struct` using the `with` attribute:
+
+```rust
+#[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
+#[native_model(id = 1, version = 1, with = native_model::rmp_serde_1_3::RmpSerde)]
+struct MyStruct {
+	my_string: String,
+	// etc.
+}
+```
+
+###### Additional reading
+
+You may also want to check out [David Koloski](https://github.com/djkoloski)'s [Rust serialization benchmarks](https://github.com/djkoloski/rust_serialization_benchmark) for help selecting the codec (i.e. `bincode_1_3`, `rmp_serde_1_3`, etc.) that's best for your project.
+
 ## Status
 
 Early development. Not ready for production.

--- a/src/codec/bincode_1_3.rs
+++ b/src/codec/bincode_1_3.rs
@@ -1,4 +1,4 @@
-//! ⚠️ [`Read the docs before using`](crate::bincode_1_3::Bincode#warning).
+//! ⚠️ [`Read the docs before using`](crate::bincode_1_3::Bincode#warning) -
 //! Annotate your type with `native_model::bincode_1_3::Bincode` to use the
 //! bincode 1.3 crate for serializing & deserializing.
 

--- a/src/codec/bincode_1_3.rs
+++ b/src/codec/bincode_1_3.rs
@@ -1,9 +1,9 @@
-//! ⚠️ [`Read the docs before using`](crate::bincode_1_3::Bincode#warning) -
-//! Annotate your type with `native_model::bincode_1_3::Bincode` to have
-//! `native_db` use the bincode 1.3 crate for serializing & deserializing.
+//! [bincode 1.3](https://crates.io/crates/bincode/1.3.3) ·
+//! The default codec for serializing & deserializing.
 
-/// Used to specify the [bincode](https://crates.io/crates/bincode/1.3.3) `1.3`
-/// crate for serialization & deserialization.
+/// Used to specify that the
+/// [bincode 1.3](https://crates.io/crates/bincode/1.3.3) crate is to be used
+/// for serialization & deserialization.
 ///
 /// # Warning
 ///

--- a/src/codec/bincode_1_3.rs
+++ b/src/codec/bincode_1_3.rs
@@ -1,19 +1,48 @@
-use bincode_1_3::{deserialize, serialize, Error};
-use serde::{Deserialize, Serialize};
+//! ⚠️ [`Read the docs before using`](crate::bincode_1_3::Bincode#warning).
+//! Annotate your type with `native_model::bincode_1_3::Bincode` to use the
+//! bincode 1.3 crate for serializing & deserializing.
 
+/// Used to specify the [bincode](https://crates.io/crates/bincode/1.3.3) `1.3`
+/// crate for serialization & deserialization.
+///
+/// # Warning
+///
+/// `bincode` [does not implement](https://github.com/bincode-org/bincode/issues/548)
+/// all [serde](https://crates.io/crates/serde) features. Errors may be
+/// encountered when using this with some types.
+///
+/// # Basic usage
+///
+/// Use the [`with`](crate::native_model) attribute on your type to instruct
+/// `native_model` to use `Bincode` for serialization & deserialization.
+///
+/// Example:
+///
+/// ```rust
+/// #[native_model(id = 1, version = 1, with = native_model::bincode_1_3::Bincode)]
+/// struct MyStruct {
+///     my_string: String
+/// }
+/// ```
+
+#[doc(cfg(all(feature = "serde", feature = "bincode_1_3")))]
 #[derive(Default)]
 pub struct Bincode;
 
-impl<T: Serialize> super::Encode<T> for Bincode {
-    type Error = Error;
-    fn encode(obj: &T) -> Result<Vec<u8>, Error> {
-        Ok(serialize(obj)?)
+#[cfg(all(feature = "serde", feature = "bincode_1_3"))]
+impl<T: serde::Serialize> super::Encode<T> for Bincode {
+    type Error = bincode_1_3::Error;
+    /// Serializes a type into bytes using the `bincode` `1.3` crate.
+    fn encode(obj: &T) -> Result<Vec<u8>, Self::Error> {
+        bincode_1_3::serialize(obj)
     }
 }
 
-impl<T: for<'a> Deserialize<'a>> super::Decode<T> for Bincode {
-    type Error = Error;
-    fn decode(data: Vec<u8>) -> Result<T, Error> {
-        Ok(deserialize(&data[..])?)
+#[cfg(all(feature = "serde", feature = "bincode_1_3"))]
+impl<T: for<'de> serde::Deserialize<'de>> super::Decode<T> for Bincode {
+    type Error = bincode_1_3::Error;
+    /// Deserializes a type from bytes using the `bincode` `1.3` crate.
+    fn decode(data: Vec<u8>) -> Result<T, Self::Error> {
+        bincode_1_3::deserialize(&data[..])
     }
 }

--- a/src/codec/bincode_1_3.rs
+++ b/src/codec/bincode_1_3.rs
@@ -1,6 +1,6 @@
 //! ⚠️ [`Read the docs before using`](crate::bincode_1_3::Bincode#warning) -
-//! Annotate your type with `native_model::bincode_1_3::Bincode` to use the
-//! bincode 1.3 crate for serializing & deserializing.
+//! Annotate your type with `native_model::bincode_1_3::Bincode` to have
+//! `native_db` use the bincode 1.3 crate for serializing & deserializing.
 
 /// Used to specify the [bincode](https://crates.io/crates/bincode/1.3.3) `1.3`
 /// crate for serialization & deserialization.
@@ -11,21 +11,24 @@
 /// all [serde](https://crates.io/crates/serde) features. Errors may be
 /// encountered when using this with some types.
 ///
+/// If you are encountering errors when using this codec on your types, try
+/// using the `rmp_serde_1_3` codec instead.
+///
 /// # Basic usage
 ///
 /// Use the [`with`](crate::native_model) attribute on your type to instruct
 /// `native_model` to use `Bincode` for serialization & deserialization.
 ///
-/// Example:
+/// Example usage:
 ///
 /// ```rust
+/// #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
 /// #[native_model(id = 1, version = 1, with = native_model::bincode_1_3::Bincode)]
 /// struct MyStruct {
 ///     my_string: String
 /// }
 /// ```
 
-#[doc(cfg(all(feature = "serde", feature = "bincode_1_3")))]
 #[derive(Default)]
 pub struct Bincode;
 

--- a/src/codec/bincode_1_3.rs
+++ b/src/codec/bincode_1_3.rs
@@ -21,8 +21,17 @@
 ///
 /// Example usage:
 ///
+<<<<<<< HEAD
 /// ```rust
 /// #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
+=======
+/// ```no_run
+/// # fn main() {
+/// use serde::{Deserialize, Serialize};
+/// use native_model::native_model;
+///
+/// #[derive(Clone, Default, Deserialize, Serialize)]
+>>>>>>> bded1fc (Turn off doc tests)
 /// #[native_model(id = 1, version = 1, with = native_model::bincode_1_3::Bincode)]
 /// struct MyStruct {
 ///     my_string: String

--- a/src/codec/bincode_2_rc.rs
+++ b/src/codec/bincode_2_rc.rs
@@ -1,4 +1,4 @@
-//! ⚠️ [`Read the docs before using`](crate::bincode_2_rc::Bincode#warning).
+//! ⚠️ [`Read the docs before using`](crate::bincode_2_rc::Bincode#warning) -
 //! Annotate your type with `native_model::bincode_2_rc::Bincode` to use
 //! the bincode 2.0.0-rc.3 crate for serializing & deserializing.
 

--- a/src/codec/bincode_2_rc.rs
+++ b/src/codec/bincode_2_rc.rs
@@ -1,10 +1,11 @@
-//! ⚠️ [`Read the docs before using`](crate::bincode_2_rc::Bincode#warning) -
+//! [bincode 2.0.0-rc.3](https://crates.io/crates/bincode/2.0.0-rc.3) ·
 //! Enable the `bincode_2_rc` feature and annotate your type with
-//! `native_model::bincode_2_rc::Bincode` to have `native_db` use the bincode
-//! 2.0.0-rc.3 crate for serializing & deserializing.
+//! `native_model::bincode_2_rc::Bincode` to have `native_db` use this crate for
+//! serializing & deserializing.
 
-/// Used to specify the [bincode](https://crates.io/crates/bincode/2.0.0-rc.3)
-/// `2.0.0-rc.3` crate for serialization & deserialization.
+/// Used to specify the
+/// [bincode 2.0.0-rc.3](https://crates.io/crates/bincode/2.0.0-rc.3)
+/// crate for serialization & deserialization.
 ///
 /// # Warning
 ///

--- a/src/codec/bincode_2_rc.rs
+++ b/src/codec/bincode_2_rc.rs
@@ -1,6 +1,7 @@
 //! ⚠️ [`Read the docs before using`](crate::bincode_2_rc::Bincode#warning) -
-//! Annotate your type with `native_model::bincode_2_rc::Bincode` to use
-//! the bincode 2.0.0-rc.3 crate for serializing & deserializing.
+//! Enable the `bincode_2_rc` feature and annotate your type with
+//! `native_model::bincode_2_rc::Bincode` to have `native_db` use the bincode
+//! 2.0.0-rc.3 crate for serializing & deserializing.
 
 /// Used to specify the [bincode](https://crates.io/crates/bincode/2.0.0-rc.3)
 /// `2.0.0-rc.3` crate for serialization & deserialization.
@@ -11,21 +12,25 @@
 /// all [serde](https://crates.io/crates/serde) features. Errors may be
 /// encountered when using this with some types.
 ///
+/// If you are encountering errors when using this codec on your types, try
+/// using the `rmp_serde_1_3` codec instead.
+///
 /// # Basic usage
 ///
-/// Use the [`with`](crate::native_model) attribute on your type to instruct
+/// After enabling the `bincode_2_rc` feature in your `Cargo.toml`, use the
+/// [`with`](crate::native_model) attribute on your type to instruct
 /// `native_model` to use `Bincode` for serialization & deserialization.
 ///
-/// Example:
+/// Example usage:
 ///
 /// ```rust
+/// #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
 /// #[native_model(id = 1, version = 1, with = native_model::bincode_2_rc::Bincode)]
 /// struct MyStruct {
 ///     my_string: String
 /// }
 /// ```
 
-#[doc(cfg(all(feature = "serde", feature = "bincode_2_rc")))]
 pub struct Bincode;
 
 #[cfg(all(feature = "serde", feature = "bincode_2_rc"))]

--- a/src/codec/bincode_2_rc.rs
+++ b/src/codec/bincode_2_rc.rs
@@ -24,8 +24,17 @@
 ///
 /// Example usage:
 ///
+<<<<<<< HEAD
 /// ```rust
 /// #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
+=======
+/// ```no_run
+/// # fn main() {
+/// use serde::{Deserialize, Serialize};
+/// use native_model::native_model;
+///
+/// #[derive(Clone, Default, Deserialize, Serialize)]
+>>>>>>> bded1fc (Turn off doc tests)
 /// #[native_model(id = 1, version = 1, with = native_model::bincode_2_rc::Bincode)]
 /// struct MyStruct {
 ///     my_string: String

--- a/src/codec/bincode_2_rc.rs
+++ b/src/codec/bincode_2_rc.rs
@@ -1,22 +1,53 @@
-use bincode_2_rc::{
-    config,
-    error::{DecodeError, EncodeError},
-    serde::{decode_from_slice, encode_to_vec},
-};
-use serde::{Deserialize, Serialize};
+//! ⚠️ [`Read the docs before using`](crate::bincode_2_rc::Bincode#warning).
+//! Annotate your type with `native_model::bincode_2_rc::Bincode` to use
+//! the bincode 2.0.0-rc.3 crate for serializing & deserializing.
 
+/// Used to specify the [bincode](https://crates.io/crates/bincode/2.0.0-rc.3)
+/// `2.0.0-rc.3` crate for serialization & deserialization.
+///
+/// # Warning
+///
+/// `bincode` [does not implement](https://docs.rs/bincode/2.0.0-rc.3/bincode/serde/index.html#known-issues)
+/// all [serde](https://crates.io/crates/serde) features. Errors may be
+/// encountered when using this with some types.
+///
+/// # Basic usage
+///
+/// Use the [`with`](crate::native_model) attribute on your type to instruct
+/// `native_model` to use `Bincode` for serialization & deserialization.
+///
+/// Example:
+///
+/// ```rust
+/// #[native_model(id = 1, version = 1, with = native_model::bincode_2_rc::Bincode)]
+/// struct MyStruct {
+///     my_string: String
+/// }
+/// ```
+
+#[doc(cfg(all(feature = "serde", feature = "bincode_2_rc")))]
 pub struct Bincode;
 
-impl<T: Serialize> super::Encode<T> for Bincode {
-    type Error = EncodeError;
-    fn encode(obj: &T) -> Result<Vec<u8>, EncodeError> {
-        encode_to_vec(obj, config::standard())
+#[cfg(all(feature = "serde", feature = "bincode_2_rc"))]
+impl<T: serde::Serialize> super::Encode<T> for Bincode {
+    type Error = bincode_2_rc::error::EncodeError;
+    /// Serializes a type into bytes using the `bincode` `2.0.0-rc.3` crate.
+    fn encode(obj: &T) -> Result<Vec<u8>, Self::Error> {
+        bincode_2_rc::serde::encode_to_vec(
+            obj,
+            bincode_2_rc::config::standard()
+        )
     }
 }
 
-impl<T: for<'a> Deserialize<'a>> super::Decode<T> for Bincode {
-    type Error = DecodeError;
-    fn decode(data: Vec<u8>) -> Result<T, DecodeError> {
-        Ok(decode_from_slice(&data, config::standard())?.0)
+#[cfg(all(feature = "serde", feature = "bincode_2_rc"))]
+impl<T: for<'de> serde::Deserialize<'de>> super::Decode<T> for Bincode {
+    type Error = bincode_2_rc::error::DecodeError;
+    /// Deserializes a type from bytes using the `bincode` `2.0.0-rc.3` crate.
+    fn decode(data: Vec<u8>) -> Result<T, Self::Error> {
+        Ok(bincode_2_rc::serde::decode_from_slice(
+            &data,
+            bincode_2_rc::config::standard()
+        )?.0)
     }
 }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -14,7 +14,7 @@ pub mod rmp_serde_1_3;
 ///
 /// Example:
 /// ```rust
-///  use bincode_2_rc::{error::EncodeError,serde::encode_to_vec, config::standard};
+/// use bincode_2_rc::{error::EncodeError,serde::encode_to_vec, config::standard};
 /// use serde::Serialize;
 /// pub struct Bincode;
 ///
@@ -27,6 +27,12 @@ pub mod rmp_serde_1_3;
 /// ```
 pub trait Encode<T> {
     type Error;
+    /// Encodes a `T` type into a series of bytes.
+    ///
+    /// # Errors
+    ///
+    /// The errors returned from this function depend on the trait implementor
+    /// (the serializer), i.e. `bincode_2_rc`.
     fn encode(obj: &T) -> Result<Vec<u8>, Self::Error>;
 }
 
@@ -46,5 +52,11 @@ pub trait Encode<T> {
 /// }
 pub trait Decode<T> {
     type Error;
+    /// Decodes a series of bytes back into a `T` type.
+    ///
+    /// # Errors
+    ///
+    /// The errors returned from this function depend on the trait implementor
+    /// (the deserializer), i.e. `bincode_2_rc`.
     fn decode(data: Vec<u8>) -> Result<T, Self::Error>;
 }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,9 +1,14 @@
-#[cfg(all(feature = "serde", feature = "bincode_1_3"))]
+//! Traits and implementations for encoding types into a series of bytes and
+//! decoding bytes back into types.
+
+#[cfg(any(all(feature = "serde", feature = "bincode_1_3"), doc))]
 pub mod bincode_1_3;
-#[cfg(all(feature = "serde", feature = "bincode_2_rc"))]
+#[cfg(any(all(feature = "serde", feature = "bincode_2_rc"), doc))]
 pub mod bincode_2_rc;
-#[cfg(all(feature = "serde", feature = "postcard_1_0"))]
+#[cfg(any(all(feature = "serde", feature = "postcard_1_0"), doc))]
 pub mod postcard_1_0;
+#[cfg(any(all(feature = "serde", feature = "rmp_serde_1_3"), doc))]
+pub mod rmp_serde_1_3;
 
 /// Encode trait for your own encoding method.
 ///

--- a/src/codec/postcard_1_0.rs
+++ b/src/codec/postcard_1_0.rs
@@ -21,8 +21,17 @@
 ///
 /// Example usage:
 ///
+<<<<<<< HEAD
 /// ```rust
 /// #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
+=======
+/// ```no_run
+/// # fn main() {
+/// use serde::{Deserialize, Serialize};
+/// use native_model::native_model;
+///
+/// #[derive(Clone, Default, Deserialize, Serialize)]
+>>>>>>> bded1fc (Turn off doc tests)
 /// #[native_model(id = 1, version = 1, with = native_model::postcard_1_0::PostCard)]
 /// struct MyStruct {
 ///     my_string: String

--- a/src/codec/postcard_1_0.rs
+++ b/src/codec/postcard_1_0.rs
@@ -1,18 +1,46 @@
-use postcard_1_0::{from_bytes, to_allocvec, Error};
-use serde::{Deserialize, Serialize};
+//! ⚠️ [`Read the docs before using`](crate::postcard_1_0::PostCard#warning).
+//! Annotate your type with `native_model::postcard_1_0::PostCard` to
+//! use the postcard 1.0 crate for serializing & deserializing.
 
+/// Used to specify the [postcard](https://crates.io/crates/postcard/1.0.8)
+/// `1.0` crate for serialization & deserialization.
+///
+/// # Warning
+///
+/// `postcard` does not implement all [serde](https://crates.io/crates/serde)
+/// features. Errors may be encountered when using this with some types.
+///
+/// # Basic usage
+///
+/// Use the [`with`](crate::native_model) attribute on your type to instruct
+/// `native_model` to use `PostCard` for serialization & deserialization.
+///
+/// Example:
+///
+/// ```rust
+/// #[native_model(id = 1, version = 1, with = native_model::postcard_1_0::PostCard)]
+/// struct MyStruct {
+///     my_string: String
+/// }
+/// ```
+
+#[doc(cfg(all(feature = "serde", feature = "postcard_1_0")))]
 pub struct PostCard;
 
-impl<T: Serialize> super::Encode<T> for PostCard {
-    type Error = Error;
-    fn encode(obj: &T) -> Result<Vec<u8>, Error> {
-        Ok(to_allocvec(obj)?)
+#[cfg(all(feature = "serde", feature = "postcard_1_0"))]
+impl<T: serde::Serialize> super::Encode<T> for PostCard {
+    type Error = postcard_1_0::Error;
+    /// Serializes a type into bytes using the `postcard` `1.0` crate.
+    fn encode(obj: &T) -> Result<Vec<u8>, Self::Error> {
+        postcard_1_0::to_allocvec(obj)
     }
 }
 
-impl<T: for<'a> Deserialize<'a>> super::Decode<T> for PostCard {
-    type Error = Error;
-    fn decode(data: Vec<u8>) -> Result<T, Error> {
-        Ok(from_bytes(&data)?)
+#[cfg(all(feature = "serde", feature = "postcard_1_0"))]
+impl<T: for<'de> serde::Deserialize<'de>> super::Decode<T> for PostCard {
+    type Error = postcard_1_0::Error;
+    /// Deserializes a type from bytes using the `postcard` `1.0` crate.
+    fn decode(data: Vec<u8>) -> Result<T, Self::Error> {
+        postcard_1_0::from_bytes(&data)
     }
 }

--- a/src/codec/postcard_1_0.rs
+++ b/src/codec/postcard_1_0.rs
@@ -1,4 +1,4 @@
-//! ⚠️ [`Read the docs before using`](crate::postcard_1_0::PostCard#warning).
+//! ⚠️ [`Read the docs before using`](crate::postcard_1_0::PostCard#warning) -
 //! Annotate your type with `native_model::postcard_1_0::PostCard` to
 //! use the postcard 1.0 crate for serializing & deserializing.
 

--- a/src/codec/postcard_1_0.rs
+++ b/src/codec/postcard_1_0.rs
@@ -1,10 +1,9 @@
-//! ⚠️ [`Read the docs before using`](crate::postcard_1_0::PostCard#warning) -
+//! [postcard 1.0](https://crates.io/crates/postcard/1.0.8) ·
 //! Enable the `postcard_1_0` feature and annotate your type with
-//! `native_model::postcard_1_0::PostCard` to have `native_db` use the postcard
-//! 1.0 crate for serializing & deserializing.
+//! `native_model::postcard_1_0::PostCard` to have `native_db` use this crate.
 
-/// Used to specify the [postcard](https://crates.io/crates/postcard/1.0.8)
-/// `1.0` crate for serialization & deserialization.
+/// Used to specify the [postcard 1.0](https://crates.io/crates/postcard/1.0.8)
+/// crate for serialization & deserialization.
 ///
 /// # Warning
 ///

--- a/src/codec/postcard_1_0.rs
+++ b/src/codec/postcard_1_0.rs
@@ -1,6 +1,7 @@
 //! ⚠️ [`Read the docs before using`](crate::postcard_1_0::PostCard#warning) -
-//! Annotate your type with `native_model::postcard_1_0::PostCard` to
-//! use the postcard 1.0 crate for serializing & deserializing.
+//! Enable the `postcard_1_0` feature and annotate your type with
+//! `native_model::postcard_1_0::PostCard` to have `native_db` use the postcard
+//! 1.0 crate for serializing & deserializing.
 
 /// Used to specify the [postcard](https://crates.io/crates/postcard/1.0.8)
 /// `1.0` crate for serialization & deserialization.
@@ -10,21 +11,25 @@
 /// `postcard` does not implement all [serde](https://crates.io/crates/serde)
 /// features. Errors may be encountered when using this with some types.
 ///
+/// If you are encountering errors when using this codec on your types, try
+/// using the `rmp_serde_1_3` codec instead.
+///
 /// # Basic usage
 ///
-/// Use the [`with`](crate::native_model) attribute on your type to instruct
+/// After enabling the `postcard_1_0` feature in your `Cargo.toml`, use the
+/// [`with`](crate::native_model) attribute on your type to instruct
 /// `native_model` to use `PostCard` for serialization & deserialization.
 ///
-/// Example:
+/// Example usage:
 ///
 /// ```rust
+/// #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
 /// #[native_model(id = 1, version = 1, with = native_model::postcard_1_0::PostCard)]
 /// struct MyStruct {
 ///     my_string: String
 /// }
 /// ```
 
-#[doc(cfg(all(feature = "serde", feature = "postcard_1_0")))]
 pub struct PostCard;
 
 #[cfg(all(feature = "serde", feature = "postcard_1_0"))]

--- a/src/codec/rmp_serde_1_3.rs
+++ b/src/codec/rmp_serde_1_3.rs
@@ -1,0 +1,41 @@
+//! [`Annotate your type`](crate::native_model) with
+//! `native_model::rmp_serde_1_3::RmpSerde` to use the rmp-serde 1.3 crate for
+//! serializing & deserializing.
+
+/// Used to specify the [rmp-serde](https://crates.io/crates/rmp-serde/1.3.0)
+/// `1.3` crate for serialization & deserialization.
+///
+/// # Basic usage
+///
+/// Use the [`with`](crate::native_model) attribute on your type to instruct
+/// `native_model` to use `RmpSerde` for serialization & deserialization.
+///
+/// Example:
+///
+/// ```rust
+/// #[native_model(id = 1, version = 1, with = native_model::rmp_serde_1_3::RmpSerde)]
+/// struct MyStruct {
+///     my_string: String
+/// }
+/// ```
+
+#[doc(cfg(all(feature = "serde", feature = "rmp_serde_1_3")))]
+pub struct RmpSerde;
+
+#[cfg(all(feature = "serde", feature = "rmp_serde_1_3"))]
+impl<T: serde::Serialize> crate::Encode<T> for RmpSerde {
+    type Error = rmp_serde_1_3::encode::Error;
+    /// Serializes a type into bytes using the `rmp-serde` `1.3` crate.
+    fn encode(obj: &T) -> Result<Vec<u8>, Self::Error> {
+        rmp_serde_1_3::encode::to_vec(obj)
+    }
+}
+
+#[cfg(all(feature = "serde", feature = "rmp_serde_1_3"))]
+impl<T: for<'de> serde::Deserialize<'de>> crate::Decode<T> for RmpSerde {
+    type Error = rmp_serde_1_3::decode::Error;
+    /// Deserializes a type from bytes using the `rmp-serde` `1.3` crate.
+    fn decode(data: Vec<u8>) -> Result<T, Self::Error> {
+        rmp_serde_1_3::decode::from_slice(&data)
+    }
+}

--- a/src/codec/rmp_serde_1_3.rs
+++ b/src/codec/rmp_serde_1_3.rs
@@ -1,10 +1,11 @@
+//! [rmp-serde 1.3](https://crates.io/crates/rmp-serde/1.3.0) ·
 //! Enable the `rmp_serde_1_3` feature and
 //! [`annotate your type`](crate::native_model) with
-//! `native_model::rmp_serde_1_3::RmpSerde` to have `native_db` use the
-//! rmp-serde 1.3 crate for serializing & deserializing.
+//! `native_model::rmp_serde_1_3::RmpSerde` to have `native_db` use this crate.
 
-/// Used to specify the [rmp-serde](https://crates.io/crates/rmp-serde/1.3.0)
-/// `1.3` crate for serialization & deserialization.
+/// Used to specify the
+/// [rmp-serde 1.3](https://crates.io/crates/rmp-serde/1.3.0)
+/// crate for serialization & deserialization.
 ///
 /// # Basic usage
 ///

--- a/src/codec/rmp_serde_1_3.rs
+++ b/src/codec/rmp_serde_1_3.rs
@@ -15,8 +15,17 @@
 ///
 /// Example usage:
 ///
+<<<<<<< HEAD
 /// ```rust
 /// #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
+=======
+/// ```no_run
+/// # fn main() {
+/// use serde::{Deserialize, Serialize};
+/// use native_model::native_model;
+///
+/// #[derive(Clone, Default, Deserialize, Serialize)]
+>>>>>>> bded1fc (Turn off doc tests)
 /// #[native_model(id = 1, version = 1, with = native_model::rmp_serde_1_3::RmpSerde)]
 /// struct MyStruct {
 ///     my_string: String

--- a/src/codec/rmp_serde_1_3.rs
+++ b/src/codec/rmp_serde_1_3.rs
@@ -1,25 +1,27 @@
-//! [`Annotate your type`](crate::native_model) with
-//! `native_model::rmp_serde_1_3::RmpSerde` to use the rmp-serde 1.3 crate for
-//! serializing & deserializing.
+//! Enable the `rmp_serde_1_3` feature and
+//! [`annotate your type`](crate::native_model) with
+//! `native_model::rmp_serde_1_3::RmpSerde` to have `native_db` use the
+//! rmp-serde 1.3 crate for serializing & deserializing.
 
 /// Used to specify the [rmp-serde](https://crates.io/crates/rmp-serde/1.3.0)
 /// `1.3` crate for serialization & deserialization.
 ///
 /// # Basic usage
 ///
-/// Use the [`with`](crate::native_model) attribute on your type to instruct
+/// After enabling the `rmp_serde_1_3` feature in your `Cargo.toml`, use the
+/// [`with`](crate::native_model) attribute on your type to instruct
 /// `native_model` to use `RmpSerde` for serialization & deserialization.
 ///
-/// Example:
+/// Example usage:
 ///
 /// ```rust
+/// #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
 /// #[native_model(id = 1, version = 1, with = native_model::rmp_serde_1_3::RmpSerde)]
 /// struct MyStruct {
 ///     my_string: String
 /// }
 /// ```
 
-#[doc(cfg(all(feature = "serde", feature = "rmp_serde_1_3")))]
 pub struct RmpSerde;
 
 #[cfg(all(feature = "serde", feature = "rmp_serde_1_3"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,64 @@
 //!
 //! See examples in the [README.md](https://github.com/vincent-herlemont/native_model) file.
 //!
-//! You may also want to check [David Koloski](https://github.com/djkoloski)'s
+//! # Codecs
+//!
+//! `native_model` comes with several optional built-in serializer features
+//! available:
+//!
+//! - [bincode](https://crates.io/crates/bincode/1.3.3) `1.3` ·
+//! [`Annotate your type`](crate::native_model) with
+//! `native_model::bincode_1_3::Bincode` to have `native_db` use this default
+//! codec for serializing & deserializing. **Warning: This codec may not work
+//! with all serde-derived types.**
+//!
+//! - [bincode](https://crates.io/crates/bincode/2.0.0-rc.3) `2.0.0-rc.3` ·
+//! Enable the `bincode_2_rc` feature and use the
+//! `native_model::bincode_2_rc::Bincode` attribute to have `native_db` use this
+//! crate. **Warning: This codec may not work with all serde-derived types.**
+//!
+//! - [postcard](https://crates.io/crates/postcard/1.0.8) `1.0` ·
+//! Enable the `postcard_1_0` feature and use the
+//! `native_model::postcard_1_0::PostCard` attribute. **Warning: This codec may
+//! not work with all serde-derived types.**
+//!
+//! - [rmp-serde](https://crates.io/crates/rmp-serde/1.3.0) `1.3` ·
+//! Enable the `rmp_serde_1_3` feature and use the
+//! `native_model::rmp_serde_1_3::RmpSerde` attribute.
+//!
+//! ###### Codec example:
+//!
+//! As example, to use `rmp-serde`:
+//!
+//! 1. In your project's `Cargo.toml` file, enable the `rmp_serde_1_3` feature
+//! for the `native_model` dependency. Check
+//! [crates.io](https://crates.io/crates/native_model) for the most recent
+//! version number.
+//!
+//! ```toml
+//! [dependencies]
+//! serde = { version = "1.0", features = [ "derive" ] }
+//! native_model = { version = "0.4", features = [ "rmp_serde_1_3" ] }
+//! ```
+//!
+//! 2. Assign the `rmp_serde_1_3` codec to your type using the `with` attribute:
+//!
+//! ```rust
+//! #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
+//! #[native_model(id = 1, version = 1, with = native_model::rmp_serde_1_3::RmpSerde)]
+//! struct MyStruct {
+//!     my_string: String,
+//!     // etc.
+//! }
+//! ```
+//!
+//! ###### Additional reading
+//!
+//! You may also want to check out
+//! [David Koloski](https://github.com/djkoloski)'s
 //! [Rust serialization benchmarks](https://github.com/djkoloski/rust_serialization_benchmark)
 //! for help selecting the codec (i.e. `bincode_1_3`, `rmp_serde_1_3`, etc.)
 //! that's best for your project.
-
-#![feature(doc_cfg)]
 
 #[cfg(any(
     feature = "serde",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,65 +14,6 @@
 //!   - The crate is in early development, and performance is expected to improve over time.
 //!
 //! See examples in the [README.md](https://github.com/vincent-herlemont/native_model) file.
-//!
-//! # Codecs
-//!
-//! `native_model` comes with several optional built-in serializer features
-//! available:
-//!
-//! - [bincode 1.3](https://crates.io/crates/bincode/1.3.3) · This is the
-//! default codec. **Warning: This codec may not work with all serde-derived
-//! types.**
-//!
-//! - [bincode 2.0.0-rc.3](https://crates.io/crates/bincode/2.0.0-rc.3) ·
-//! Enable the `bincode_2_rc` feature and use the
-//! `native_model::bincode_2_rc::Bincode` attribute to have `native_db` use this
-//! crate for serializing & deserializing. **Warning: This codec may not work
-//! with all serde-derived types.**
-//!
-//! - [postcard 1.0](https://crates.io/crates/postcard/1.0.8) ·
-//! Enable the `postcard_1_0` feature and use the
-//! `native_model::postcard_1_0::PostCard` attribute. **Warning: This codec may
-//! not work with all serde-derived types.**
-//!
-//! - [rmp-serde 1.3](https://crates.io/crates/rmp-serde/1.3.0) ·
-//! Enable the `rmp_serde_1_3` feature and use the
-//! `native_model::rmp_serde_1_3::RmpSerde` attribute.
-//!
-//! ###### Codec example:
-//!
-//! As example, to use `rmp-serde`:
-//!
-//! 1. In your project's `Cargo.toml` file, enable the `rmp_serde_1_3` feature
-//! for the `native_model` dependency. Be sure to check `crates.io` for the most
-//! recent [`native_model`](https://crates.io/crates/native_model) version
-//! number.
-//!
-//! ```toml
-//! [dependencies]
-//! serde = { version = "1.0", features = [ "derive" ] }
-//! native_model = { version = "0.4", features = [ "rmp_serde_1_3" ] }
-//! ```
-//!
-//! 2. Assign the `rmp_serde_1_3` codec to your `struct` using the `with`
-//! attribute:
-//!
-//! ```rust
-//! #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
-//! #[native_model(id = 1, version = 1, with = native_model::rmp_serde_1_3::RmpSerde)]
-//! struct MyStruct {
-//!     my_string: String,
-//!     // etc.
-//! }
-//! ```
-//!
-//! ###### Additional reading
-//!
-//! You may also want to check out
-//! [David Koloski](https://github.com/djkoloski)'s
-//! [Rust serialization benchmarks](https://github.com/djkoloski/rust_serialization_benchmark)
-//! for help selecting the codec (i.e. `bincode_1_3`, `rmp_serde_1_3`, etc.)
-//! that's best for your project.
 
 #[cfg(any(
     feature = "serde",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,9 @@
 //! `native_model` comes with several optional built-in serializer features
 //! available:
 //!
-//! - [bincode](https://crates.io/crates/bincode/1.3.3) `1.3` ·
-//! [`Annotate your type`](crate::native_model) with
-//! `native_model::bincode_1_3::Bincode` to have `native_db` use this default
-//! codec for serializing & deserializing. **Warning: This codec may not work
-//! with all serde-derived types.**
+//! - [bincode](https://crates.io/crates/bincode/1.3.3) `1.3` · This is the
+//! default codec. **Warning: This codec may not work with all serde-derived
+//! types.**
 //!
 //! - [bincode](https://crates.io/crates/bincode/2.0.0-rc.3) `2.0.0-rc.3` ·
 //! Enable the `bincode_2_rc` feature and use the
@@ -45,9 +43,9 @@
 //! As example, to use `rmp-serde`:
 //!
 //! 1. In your project's `Cargo.toml` file, enable the `rmp_serde_1_3` feature
-//! for the `native_model` dependency. Check
-//! [crates.io](https://crates.io/crates/native_model) for the most recent
-//! version number.
+//! for the `native_model` dependency. Be sure to check `crates.io` for the most
+//! recent [`native_model`](https://crates.io/crates/native_model) version
+//! number.
 //!
 //! ```toml
 //! [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,21 +20,22 @@
 //! `native_model` comes with several optional built-in serializer features
 //! available:
 //!
-//! - [bincode](https://crates.io/crates/bincode/1.3.3) `1.3` · This is the
+//! - [bincode 1.3](https://crates.io/crates/bincode/1.3.3) · This is the
 //! default codec. **Warning: This codec may not work with all serde-derived
 //! types.**
 //!
-//! - [bincode](https://crates.io/crates/bincode/2.0.0-rc.3) `2.0.0-rc.3` ·
+//! - [bincode 2.0.0-rc.3](https://crates.io/crates/bincode/2.0.0-rc.3) ·
 //! Enable the `bincode_2_rc` feature and use the
 //! `native_model::bincode_2_rc::Bincode` attribute to have `native_db` use this
-//! crate. **Warning: This codec may not work with all serde-derived types.**
+//! crate for serializing & deserializing. **Warning: This codec may not work
+//! with all serde-derived types.**
 //!
-//! - [postcard](https://crates.io/crates/postcard/1.0.8) `1.0` ·
+//! - [postcard 1.0](https://crates.io/crates/postcard/1.0.8) ·
 //! Enable the `postcard_1_0` feature and use the
 //! `native_model::postcard_1_0::PostCard` attribute. **Warning: This codec may
 //! not work with all serde-derived types.**
 //!
-//! - [rmp-serde](https://crates.io/crates/rmp-serde/1.3.0) `1.3` ·
+//! - [rmp-serde 1.3](https://crates.io/crates/rmp-serde/1.3.0) ·
 //! Enable the `rmp_serde_1_3` feature and use the
 //! `native_model::rmp_serde_1_3::RmpSerde` attribute.
 //!
@@ -53,7 +54,8 @@
 //! native_model = { version = "0.4", features = [ "rmp_serde_1_3" ] }
 //! ```
 //!
-//! 2. Assign the `rmp_serde_1_3` codec to your type using the `with` attribute:
+//! 2. Assign the `rmp_serde_1_3` codec to your `struct` using the `with`
+//! attribute:
 //!
 //! ```rust
 //! #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,19 @@
 //!   - The crate is in early development, and performance is expected to improve over time.
 //!
 //! See examples in the [README.md](https://github.com/vincent-herlemont/native_model) file.
+//!
+//! You may also want to check [David Koloski](https://github.com/djkoloski)'s
+//! [Rust serialization benchmarks](https://github.com/djkoloski/rust_serialization_benchmark)
+//! for help selecting the codec right for your project.
+
+#![feature(doc_cfg)]
 
 #[cfg(any(
     feature = "serde",
     feature = "bincode_1_3",
     feature = "bincode_2_rc",
-    feature = "postcard_1_0"
+    feature = "postcard_1_0",
+    doc
 ))]
 mod codec;
 
@@ -27,7 +34,8 @@ mod codec;
     feature = "serde",
     feature = "bincode_1_3",
     feature = "bincode_2_rc",
-    feature = "postcard_1_0"
+    feature = "postcard_1_0",
+    doc
 ))]
 pub use codec::*;
 mod header;
@@ -187,7 +195,6 @@ pub trait Model: Sized {
     where
         Self: Sized,
     {
-        let version = version.clone();
         let mut data = self.native_model_encode_downgrade_body(version)?;
         let data = crate::native_model_encode(&mut data, Self::native_model_id(), version);
         Ok(data)

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -18,7 +18,7 @@ impl<T: ByteSlice> Wrapper<T> {
         Some(native_model)
     }
 
-    pub fn value(&self) -> &T {
+    pub const fn value(&self) -> &T {
         &self.value
     }
 


### PR DESCRIPTION
* Housekeeping: removed extra unnecessary `Sized` bounds already declared in the trait
* Support for `rmp-serde`
* Visibility to feature-gated codecs in the docs.