### PR TITLE
ci: add comprehensive formatting and linting setup

### DIFF
--- a/.github/workflows/clippy_check.yml
+++ b/.github/workflows/clippy_check.yml
@@ -1,0 +1,30 @@
+name: Clippy Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main, next ]
+  schedule:
+    - cron:  '0 23 * * 4'
+
+env:
+  RUST_BACKTRACE: full
+
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: extractions/setup-just@v3
+      - uses: hustcer/setup-nu@v3.19
+        with:
+          version: '0.105.1'
+        env:
+            GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
+      - name: Just version
+        run: just --version
+      - name: Clippy Check
+        run: just clippy_check 

--- a/.github/workflows/fmt_check.yml
+++ b/.github/workflows/fmt_check.yml
@@ -1,0 +1,30 @@
+name: Fmt Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main, next ]
+  schedule:
+    - cron:  '0 23 * * 4'
+
+env:
+  RUST_BACKTRACE: full
+
+jobs:
+  fmt_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: extractions/setup-just@v3
+      - uses: hustcer/setup-nu@v3.19
+        with:
+          version: '0.105.1'
+        env:
+            GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
+      - name: Just version
+        run: just --version
+      - name: Fmt Check
+        run: just fmt_check 

--- a/benches/overhead.rs
+++ b/benches/overhead.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use native_model::Model;
 use native_model_macro::native_model;
 use serde::{Deserialize, Serialize};
-use native_model::Model;
 #[derive(Serialize, Deserialize)]
 #[native_model(id = 1, version = 1)]
 struct Data(Vec<u8>);

--- a/justfile
+++ b/justfile
@@ -60,3 +60,20 @@ bench_overhead:
     cargo bench --bench overhead
 
 bench_all: bench_overhead
+
+format:
+    cargo clippy; \
+    cargo fmt --all
+
+fmt_check:
+    cargo fmt --all -- --check
+
+clippy_check:
+    rustc --version; \
+    cargo clippy --version; \
+    cargo clippy -- -D warnings
+
+# Format check
+fc:
+    just fmt_check; \
+    just clippy_check

--- a/native_model_macro/src/lib.rs
+++ b/native_model_macro/src/lib.rs
@@ -27,7 +27,7 @@ pub(crate) struct ModelAttributes {
     pub(crate) try_from: Option<(Path, Path)>,
 }
 
-impl        Default for ModelAttributes {
+impl Default for ModelAttributes {
     fn default() -> Self {
         ModelAttributes {
             id: None,
@@ -57,10 +57,7 @@ impl ModelAttributes {
                 fields.next().unwrap().clone(),
             ));
         } else {
-            panic!(
-                "Unknown attribute: {}",
-                meta.path.get_ident().unwrap().to_string()
-            );
+            panic!("Unknown attribute: {}", meta.path.get_ident().unwrap());
         }
         Ok(())
     }

--- a/native_model_macro/src/method/decode_body.rs
+++ b/native_model_macro/src/method/decode_body.rs
@@ -19,5 +19,5 @@ pub(crate) fn generate_native_model_decode_body(attrs: &ModelAttributes) -> Toke
         }
     };
 
-    gen.into()
+    gen
 }

--- a/native_model_macro/src/method/encode_body.rs
+++ b/native_model_macro/src/method/encode_body.rs
@@ -14,5 +14,5 @@ pub(crate) fn generate_native_model_encode_body(attrs: &ModelAttributes) -> Toke
         }
     };
 
-    gen.into()
+    gen
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,6 +1,6 @@
 use crate::header::Header;
 use zerocopy::little_endian::U32;
-use zerocopy::{SplitByteSlice, SplitByteSliceMut, Ref, IntoBytes};
+use zerocopy::{IntoBytes, Ref, SplitByteSlice, SplitByteSliceMut};
 
 pub struct Wrapper<T: SplitByteSlice> {
     header: Ref<T, Header>,


### PR DESCRIPTION
## Summary
- Add formatting commands to justfile (format, fmt_check, clippy_check, fc)
- Create GitHub Actions workflows for automated fmt and clippy checks
- Fix existing clippy warnings in macro code

## Test plan
- [x] Test `just format` command works correctly
- [x] Test `just fmt_check` command works correctly  
- [x] Test `just clippy_check` command works correctly
- [x] Test `just fc` (combined format check) command works correctly
- [x] Verify all clippy warnings are resolved
- [x] Ensure formatting is consistent across codebase

This brings native_model in line with native_db's robust formatting and linting approach, ensuring consistent code quality and automated CI enforcement.